### PR TITLE
Only run plugin if you are admin

### DIFF
--- a/wp-git-branch.php
+++ b/wp-git-branch.php
@@ -12,9 +12,11 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-add_action( 'admin_bar_menu', 'wpgb_git_info', 900 );
-add_action( 'wp_enqueue_scripts', 'wpgb_enqueue' );
-add_action( 'admin_enqueue_scripts', 'wpgb_enqueue' );
+if ( current_user_can( 'activate_plugin' ) ) {
+	add_action( 'admin_bar_menu', 'wpgb_git_info', 900 );
+	add_action( 'wp_enqueue_scripts', 'wpgb_enqueue' );
+	add_action( 'admin_enqueue_scripts', 'wpgb_enqueue' );
+}
 
 /**
  *


### PR DESCRIPTION
Changed it so the plugin will only run if the current user can activate
plugins i.e. Administrators / Super Administrators
